### PR TITLE
評価した盤面を記憶するNega-max法を実装した

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@
 * 可能であれば、速度等を計測して、具体的な効率化度合い、強さを示してください。
 * 納得できるところまでできたところでプルリクを出してください。
 
-[![MSBuild](https://github.com/tpu-game-2025/tick-tack-toe/actions/workflows/msbuild.yml/badge.svg)](https://github.com/tpu-game-2025/tick-tack-toe/actions/workflows/msbuild.yml)
+[![MSBuild](https://github.com/BlueAiu/tick-tack-toe/actions/workflows/msbuild.yml/badge.svg)](https://github.com/BlueAiu/tick-tack-toe/actions/workflows/msbuild.yml)
 
 （↑のソースコードの「tpu-game-2025」を自分のアカウント名に差し替えてください（２か所））

--- a/src/tick-tack-toe/tick-tack-toe.cpp
+++ b/src/tick-tack-toe/tick-tack-toe.cpp
@@ -1,5 +1,6 @@
 ﻿#include <memory>
 #include <iostream>
+#include <chrono>
 
 
 class Mass {
@@ -323,7 +324,15 @@ bool AI_Nega_Max::think(Board& b) {
 
 	int x = -1, y;
 
+	auto start = std::chrono::high_resolution_clock::now();
+
 	Simurate(b, Mass::ENEMY, &x, &y);
+
+	auto end = std::chrono::high_resolution_clock::now();
+	auto duration =
+		std::chrono::duration_cast<std::chrono::milliseconds>
+		(end - start);
+	std::cout << "実行時間: " << duration.count() << "ms\n";
 
 	if(x < 0) return false;
 

--- a/src/tick-tack-toe/tick-tack-toe.cpp
+++ b/src/tick-tack-toe/tick-tack-toe.cpp
@@ -53,6 +53,9 @@ public:
 
 // Nega-Max法
 class AI_Nega_Max : public AI {
+private:
+	std::map<uint64_t, int> memory;
+
 public:
 	AI_Nega_Max() {}
 	~AI_Nega_Max() {}
@@ -336,6 +339,7 @@ bool AI_Nega_Max::think(Board& b) {
 		std::chrono::duration_cast<std::chrono::milliseconds>
 		(end - start);
 	std::cout << "実行時間: " << duration.count() << "ms\n";
+	std::cout << "記憶している盤面数: " << memory.size() << "個\n";
 
 	if(x < 0) return false;
 
@@ -347,7 +351,6 @@ int AI_Nega_Max::Simurate(Board& b, Mass::status current, int* best_x = nullptr,
 	auto next = (current == Mass::ENEMY) ? Mass::PLAYER : Mass::ENEMY;
 
 	static const int score_win = 10000;
-	static std::map<uint64_t, int> memory;
 
 	auto result = b.calc_result();
 	if (result == current) return score_win;

--- a/src/tick-tack-toe/tick-tack-toe.cpp
+++ b/src/tick-tack-toe/tick-tack-toe.cpp
@@ -1,6 +1,7 @@
 ﻿#include <memory>
 #include <iostream>
 #include <chrono>
+#include <map>
 
 
 class Mass {
@@ -90,7 +91,7 @@ public:
 	};
 private:
 	enum {
-		BOARD_SIZE = 3,
+		BOARD_SIZE = 4,
 	};
 	Mass mass_[BOARD_SIZE][BOARD_SIZE];
 
@@ -195,6 +196,8 @@ public:
 			std::cout << "＋\n";
 		}
 	}
+
+	uint64_t GetID() const;
 };
 
 bool AI_ordered::think(Board& b)
@@ -344,11 +347,18 @@ int AI_Nega_Max::Simurate(Board& b, Mass::status current, int* best_x = nullptr,
 	auto next = (current == Mass::ENEMY) ? Mass::PLAYER : Mass::ENEMY;
 
 	static const int score_win = 10000;
+	static std::map<uint64_t, int> memory;
 
 	auto result = b.calc_result();
 	if (result == current) return score_win;
 	if (result == next) return -score_win;
 	if (result == Board::DRAW) return 0;
+
+	// 盤面を整数値に変換
+	auto curID = b.GetID();
+	// 盤面評価値が計算済みならそれを返す
+	if (best_x == nullptr && memory.find(curID) != memory.end())
+		return memory[curID];
 
 	int score_max = -score_win - 1;
 
@@ -372,5 +382,23 @@ int AI_Nega_Max::Simurate(Board& b, Mass::status current, int* best_x = nullptr,
 		}
 	}
 
+	// 計算した盤面評価値を記録する
+	memory[curID] = score_max;
+
 	return score_max;
+}
+
+uint64_t Board::GetID() const {
+
+	uint64_t ret = 0;
+
+	for (int y = 0; y < BOARD_SIZE; y++) {
+		for (int x = 0; x < BOARD_SIZE; x++) {
+
+			ret += mass_[y][x].getStatus();
+			ret <<= 2;
+		}
+	}
+
+	return ret;
 }

--- a/src/tick-tack-toe/tick-tack-toe.cpp
+++ b/src/tick-tack-toe/tick-tack-toe.cpp
@@ -13,6 +13,7 @@ private:
 	status s_ = BLANK;
 public:
 	status getStatus() const { return s_; }
+	void setStatus(status s) { s_ = s; }
 
 	bool put(status s) {
 		if (s_ != BLANK) return false;
@@ -33,6 +34,7 @@ public:
 public:
 	enum type {
 		TYPE_ORDERED = 0,
+		TYPE_NEGAMAX
 	};
 
 	static AI* createAi(type type);
@@ -47,11 +49,24 @@ public:
 	bool think(Board& b);
 };
 
+// Nega-Max法
+class AI_Nega_Max : public AI {
+public:
+	AI_Nega_Max() {}
+	~AI_Nega_Max() {}
+
+	int Simurate(Board& b, Mass::status current, int* best_x, int* best_y);
+
+	bool think(Board& b);
+};
+
 AI* AI::createAi(type type)
 {
 	switch (type) {
 	case TYPE_ORDERED:
 		return new AI_ordered();
+	case TYPE_NEGAMAX:
+		return new AI_Nega_Max();
 	default:
 		return new AI_ordered();
 		break;
@@ -63,6 +78,7 @@ AI* AI::createAi(type type)
 class Board
 {
 	friend class AI_ordered;
+	friend class AI_Nega_Max;
 
 public:
 	enum WINNER {
@@ -197,7 +213,7 @@ bool AI_ordered::think(Board& b)
 class Game
 {
 private:
-	const AI::type ai_type = AI::TYPE_ORDERED;
+	const AI::type ai_type = AI::TYPE_NEGAMAX;
 
 	Board board_;
 	Board::WINNER winner_ = Board::NOT_FINISED;
@@ -300,4 +316,52 @@ int main()
 	}
 
 	return 0;
+}
+
+
+bool AI_Nega_Max::think(Board& b) {
+
+	int x = -1, y;
+
+	Simurate(b, Mass::ENEMY, &x, &y);
+
+	if(x < 0) return false;
+
+	return b.mass_[y][x].put(Mass::ENEMY);
+}
+
+int AI_Nega_Max::Simurate(Board& b, Mass::status current, int* best_x = nullptr, int* best_y = nullptr) {
+
+	auto next = (current == Mass::ENEMY) ? Mass::PLAYER : Mass::ENEMY;
+
+	static const int score_win = 10000;
+
+	auto result = b.calc_result();
+	if (result == current) return score_win;
+	if (result == next) return -score_win;
+	if (result == Board::DRAW) return 0;
+
+	int score_max = -score_win - 1;
+
+	for (int y = 0; y < Board::BOARD_SIZE; y++) {
+		for (int x = 0; x < Board::BOARD_SIZE; x++) {
+			auto& m = b.mass_[y][x];
+			if (m.getStatus() != Mass::BLANK) continue;
+
+			m.setStatus(current);
+			int score = -Simurate(b, next);
+			m.setStatus(Mass::BLANK);
+
+
+			if (score_max < score) {
+				score_max = score;
+
+				if (best_x != nullptr) *best_x = x;
+				if (best_y != nullptr) *best_y = y;
+			}
+
+		}
+	}
+
+	return score_max;
 }


### PR DESCRIPTION
4×4の盤面で
1手目のみ30s程掛かり、それ以降は高速で手を打ちます
ただし300万以上のアイテムを記録することになりました